### PR TITLE
Small tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ##Introduction
 
-This plugin can retrive a value from a Linux sysctl variable to be used in agents and discovery.
+This plugin can retrieve a value from a Linux sysctl variable to be used in agents and discovery.
 
 Sample usage to select all machines where ipv4 forwarding is enabled:
 

--- a/README.md
+++ b/README.md
@@ -2,13 +2,18 @@
 
 ##Introduction
 
-This plugin can retrieve a value from a Linux sysctl variable to be used in agents and discovery.
+This plugin can retrieve a value from a sysctl variable to be used in agents and discovery.
 
 Sample usage to select all machines where ipv4 forwarding is enabled:
 
 ```
 $ mco find -S "sysctl('net.ipv4.conf.all.forwarding').value=1"
 ```
+
+##Portability
+
+This plugin works on all systems where sysctl(8) is installed as
+`/sbin/sysctl` such as Linux, *BSD, etc.
 
 #Installation
 


### PR DESCRIPTION
Hi,

This PR fixes a small typo and adds a mention that it's not Linux-specific. I've deployed it on OpenBSD just fine:

```
obsidian:jasper {503} mco find -S "sysctl('hw.ncpufound').value=1"
openbsd1.lan
obsidian:jasper {504} 
```
